### PR TITLE
Delivery infoDelivery-Info findById로 데이터 조회 실패시 Exception이 발생하지 않는 에러 수정

### DIFF
--- a/delivery-info-service/src/main/java/com/potatorider/service/DeliveryService.java
+++ b/delivery-info-service/src/main/java/com/potatorider/service/DeliveryService.java
@@ -11,115 +11,117 @@ import com.potatorider.exception.DeliveryNotFoundException;
 import com.potatorider.exception.RetryExhaustedException;
 import com.potatorider.publihser.DeliveryPublisher;
 import com.potatorider.repository.DeliveryRepository;
-
+import java.time.Duration;
+import java.util.concurrent.TimeoutException;
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.util.retry.Retry;
 import reactor.util.retry.RetryBackoffSpec;
 
-import java.time.Duration;
-import java.util.concurrent.TimeoutException;
-
 @Service
 @RequiredArgsConstructor
 public class DeliveryService {
 
-    private final DeliveryRepository deliveryRepository;
-    private final DeliveryPublisher deliveryPublisher;
     private static final Long MAX_ATTEMPTS = 3L;
     private static final Duration FIXED_DELAY = Duration.ofMillis(500);
+    private final DeliveryRepository deliveryRepository;
+    private final DeliveryPublisher deliveryPublisher;
 
     public Mono<Delivery> saveDelivery(final Delivery delivery) {
         return deliveryRepository
-                .save(delivery.setDeliveryStatusRequest())
-                .flatMap(
-                        del ->
-                                deliveryPublisher
-                                        .sendAddDeliveryEvent(del)
-                                        .retryWhen(retryBackoffSpec()));
+            .save(delivery.setDeliveryStatusRequest())
+            .flatMap(
+                del ->
+                    deliveryPublisher
+                        .sendAddDeliveryEvent(del)
+                        .retryWhen(retryBackoffSpec()));
     }
 
     public Mono<Delivery> acceptDelivery(final String deliveryId) {
         return deliveryRepository
-                .findById(deliveryId)
-                .flatMap(delivery -> DeliveryValidator.statusIsExpected(delivery, REQUEST))
-                .map(Delivery::nextStatus)
-                .flatMap(deliveryRepository::save)
-                .flatMap(
-                        del ->
-                                deliveryPublisher
-                                        .sendSetRiderEvent(del)
-                                        .retryWhen(retryBackoffSpec()));
+            .findById(deliveryId)
+            .switchIfEmpty(Mono.error(DeliveryNotFoundException::new))
+            .flatMap(delivery -> DeliveryValidator.statusIsExpected(delivery, REQUEST))
+            .map(Delivery::nextStatus)
+            .flatMap(deliveryRepository::save)
+            .flatMap(
+                del ->
+                    deliveryPublisher
+                        .sendSetRiderEvent(del)
+                        .retryWhen(retryBackoffSpec()));
     }
 
     public Mono<Delivery> setDeliveryRider(final String deliveryId) {
         return deliveryRepository
-                .findById(deliveryId)
-                .flatMap(delivery -> DeliveryValidator.statusIsExpected(delivery, ACCEPT))
-                .map(Delivery::nextStatus)
-                .flatMap(deliveryRepository::save);
+            .findById(deliveryId)
+            .switchIfEmpty(Mono.error(DeliveryNotFoundException::new))
+            .flatMap(delivery -> DeliveryValidator.statusIsExpected(delivery, ACCEPT))
+            .map(Delivery::nextStatus)
+            .flatMap(deliveryRepository::save);
     }
 
     public Mono<Delivery> pickUpDelivery(final String deliveryId) {
         return deliveryRepository
-                .findById(deliveryId)
-                .flatMap(delivery -> DeliveryValidator.statusIsExpected(delivery, RIDER_SET))
-                .map(Delivery::nextStatus)
-                .map(Delivery::setPickupTime)
-                .flatMap(deliveryRepository::save);
+            .findById(deliveryId)
+            .switchIfEmpty(Mono.error(DeliveryNotFoundException::new))
+            .flatMap(delivery -> DeliveryValidator.statusIsExpected(delivery, RIDER_SET))
+            .map(Delivery::nextStatus)
+            .map(Delivery::setPickupTime)
+            .flatMap(deliveryRepository::save);
     }
 
     public Mono<Delivery> completeDelivery(final String deliveryId) {
         return deliveryRepository
-                .findById(deliveryId)
-                .flatMap(
-                        delivery ->
-                                DeliveryValidator.statusIsExpected(delivery, PICKED_UP)
-                                        .map(Delivery::nextStatus)
-                                        .map(Delivery::setFinishTime)
-                                        .flatMap(deliveryRepository::save));
+            .findById(deliveryId)
+            .switchIfEmpty(Mono.error(DeliveryNotFoundException::new))
+            .flatMap(
+                delivery ->
+                    DeliveryValidator.statusIsExpected(delivery, PICKED_UP)
+                        .map(Delivery::nextStatus)
+                        .map(Delivery::setFinishTime)
+                        .flatMap(deliveryRepository::save));
     }
 
     public Mono<Delivery> findDelivery(final String deliveryId) {
         return deliveryRepository
-                .findById(deliveryId)
-                .switchIfEmpty(Mono.error(DeliveryNotFoundException::new));
+            .findById(deliveryId)
+            .switchIfEmpty(Mono.error(DeliveryNotFoundException::new));
     }
 
     public Flux<Delivery> findAllDelivery(final int page, final int size) {
         Pageable pageable = PageRequest.of(page, size);
-        return deliveryRepository.findAllBy(pageable);
+        return deliveryRepository.findAllBy(pageable)
+            .switchIfEmpty(Flux.error(DeliveryNotFoundException::new));
     }
 
     private RetryBackoffSpec retryBackoffSpec() {
         return Retry.fixedDelay(MAX_ATTEMPTS, FIXED_DELAY)
-                .filter((ex) -> ex instanceof TimeoutException)
-                .onRetryExhaustedThrow(
-                        (((retryBackoffSpec, retrySignal) ->
-                                new RetryExhaustedException(retrySignal))));
+            .filter((ex) -> ex instanceof TimeoutException)
+            .onRetryExhaustedThrow(
+                (((retryBackoffSpec, retrySignal) ->
+                    new RetryExhaustedException(retrySignal))));
     }
 
     public Mono<Boolean> isPickedUp(final String deliveryId) {
         return deliveryRepository
-                .findById(deliveryId)
-                .flatMap(delivery -> Mono.just(delivery.getDeliveryStatus().equals(PICKED_UP)))
-                .onErrorReturn(false);
+            .findById(deliveryId)
+            .switchIfEmpty(Mono.error(DeliveryNotFoundException::new))
+            .flatMap(delivery -> Mono.just(delivery.getDeliveryStatus().equals(PICKED_UP)))
+            .onErrorReturn(false);
     }
 
     private static class DeliveryValidator {
 
         public static Mono<Delivery> statusIsExpected(Delivery delivery, DeliveryStatus expected) {
             return delivery.getDeliveryStatus().equals(expected)
-                    ? Mono.just(delivery)
-                    : Mono.error(
-                            new IllegalStateException(
-                                    String.format("주문 상태가 %s 가 아닙니다.", expected)));
+                ? Mono.just(delivery)
+                : Mono.error(
+                    new IllegalStateException(
+                        String.format("주문 상태가 %s 가 아닙니다.", expected)));
         }
     }
 }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
#70 Delivery-Info findById로 데이터 조회 실패시 Exception이 발생하지 않는 에러 수정

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더 삭제